### PR TITLE
Update POM for compatibility with recent TownyChat releases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,25 +7,21 @@
     <groupId>com.extendedclip.papi.expansion</groupId>
     <artifactId>townychat</artifactId>
     <name>Expansion-TownyChat</name>
-    <version>1.0</version>
+    <version>1.1</version>
 
-    <description>Example of how to bundle a PlaceholderExpansion with your plugin</description>
+    <description>A Placeholder Expansion for TownyChat by LlmDl</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>
         <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
-            <id>clips-public-repo</id>
-            <url>http://repo.extendedclip.com/content/repositories/public</url>
-        </repository>
-        <repository>
-            <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -33,23 +29,23 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <version>1.16.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>me.clip</groupId>
-            <artifactId>placeholderapi</artifactId>
-            <version>2.10.2</version>
+            <groupId>com.github.PlaceholderAPI</groupId>
+            <artifactId>PlaceholderAPI</artifactId>
+            <version>2.10.9</version>
         </dependency>
         <dependency>
-            <groupId>com.palmergames.bukkit.TownyChat</groupId>
-            <artifactId>Chat</artifactId>
-            <version>0.53</version>
+            <groupId>com.github.TownyAdvanced</groupId>
+            <artifactId>TownyChat</artifactId>
+            <version>0.84</version>
         </dependency>
         <dependency>
-            <groupId>com.palmergames.bukkit.towny</groupId>
+            <groupId>com.github.TownyAdvanced</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.93.0.0</version>
+            <version>0.96.5.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Several placeholders, including `%townychat_channel_name%`, do not currently work in modern versions of TownyChat / Towny.
After some testing [(Compiled Here)](https://github.com/the-lockedcraft-legacy-organization/TownyChat-Expansion/releases/tag/1.1), it would appear that updating the dependencies fixes all impacted placeholders.
